### PR TITLE
Allows for the creation of a resolver when no attributes other then the default active record attributes are added to the model

### DIFF
--- a/lib/hai/create.rb
+++ b/lib/hai/create.rb
@@ -14,7 +14,7 @@ module Hai
 
       return unauthorized_error unless check_policy(instance)
 
-      instance.assign_attributes(**attrs)
+      instance.assign_attributes(**attrs) unless attrs.empty?
 
       run_action_modification(instance)
 

--- a/lib/hai/graphql/create_mutations.rb
+++ b/lib/hai/graphql/create_mutations.rb
@@ -15,6 +15,7 @@ module Hai
           klass.description("Attributes for creating or updating a #{model}.")
           model.attribute_types.each do |attr, type|
             next if %w[id created_at updated_at].include?(attr)
+            next if attr.blank? # if the model has no other attributes
 
             klass.argument(
               attr,
@@ -26,7 +27,7 @@ module Hai
 
           klass.field(:result, ::Types.const_get("#{model}Type"))
 
-          klass.define_method(:resolve) do |args|
+          klass.define_method(:resolve) do |args = {}|
             Hai::Create.new(model, context).execute(**args)
           end
           Hai::GraphQL::Types.const_set("Create#{model}", klass)


### PR DESCRIPTION
Closes: https://github.com/basicBrogrammer/hai/issues/2