### PR TITLE
Updates to Generators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /pkg/
 /spec/reports/
 /tmp/
+/.vscode/

--- a/lib/generators/install/all_generator.rb
+++ b/lib/generators/install/all_generator.rb
@@ -1,0 +1,26 @@
+require 'rails/generators'
+require 'rails/generators/base'
+
+module Hai
+  module Install
+    class AllGenerator < Rails::Generators::Base
+      class_option :nullify_session, type: :boolean, default: false
+
+      def install_graphql
+        generate "hai:install:graphql", build_options_string
+      end
+
+      def install_rest
+        generate "hai:install:rest"
+      end
+
+      private
+
+      def build_options_string
+        options_string = ""
+        options_string << ("--nullify_session") if options[:nullify_session]
+        options_string
+      end
+    end
+  end
+end

--- a/lib/generators/install/graphql_generator.rb
+++ b/lib/generators/install/graphql_generator.rb
@@ -4,19 +4,26 @@ require 'rails/generators/base'
 module Hai
   module Install
     class GraphqlGenerator < Rails::Generators::Base
+      class_option :nullify_session, type: :boolean, default: false
+
       def rails_preload
         Rails.application.eager_load!
       end
 
       def install_graphql_ruby
-        gem 'graphql'
+        generate "graphql:install"
         run "bundle install"
-        run "rails generate graphql:install"
+      end
+
+      def nullify_session
+        if options[:nullify_session]
+          gsub_file 'app/controllers/graphql_controller.rb', '# protect_from_forgery with: :null_session', 'protect_from_forgery with: :null_session'
+        end
       end
 
       def add_types
         hai_types = "hay_types(#{model_names.join(', ')})"
-        inject_into_file "app/graphql/#{app_name.underscore}_schema.rb", after: "class #{app_name}Schema < GraphQL::Schema" do <<~RUBY.indent(4)
+        inject_into_file "app/graphql/#{app_name.underscore}_schema.rb", after: "class #{app_name}Schema < GraphQL::Schema" do <<~RUBY.indent(2)
 
           include Hai::GraphQL::Types
           hai_types(#{model_names.join(', ')})

--- a/lib/generators/install/rest_generator.rb
+++ b/lib/generators/install/rest_generator.rb
@@ -2,8 +2,8 @@ require 'rails/generators'
 require 'rails/generators/base'
 
 module Hai
-  module Rest
-    class InstallGenerator < Rails::Generators::Base
+  module Install
+    class RestGenerator < Rails::Generators::Base
       def mount_engine
         route <<-RUBY
           mount Hai::Rest::Engine => "/rest"

--- a/lib/hai.rb
+++ b/lib/hai.rb
@@ -16,9 +16,13 @@ require_relative "hai/restricted_attributes"
 
 require_relative "hai/policies"
 require_relative "hai/action_mods"
-require "hai/railtie" if defined?(Rails)
-require "generators/rest/install_generator" if defined?(Rails)
-require "generators/install/graphql_generator" if defined?(Rails)
+
+if defined?(Rails)
+  require "hai/railtie"
+  require "generators/install/rest_generator"
+  require "generators/install/graphql_generator"
+  require "generators/install/all_generator"
+end
 
 module Hai
   class Error < StandardError


### PR DESCRIPTION
Made a couple changes to the generators based on some testing on a new app.  These include the following

* I've remove adding the `graphql` gem within the script.  This is already a dependency in `Hai` so it doesn't seem to be needed here.
* Running `bundle install` after running the `graphql:install` script.  The gem recomends this because it adds `graphiql-rails` to our gem file but doesn't install it.
* added the option to `nullify_session` when running `hai::install::graphql`.  This modifies uncomments the line in the [GraphQLController](https://github.com/rmosolgo/graphql-ruby/blob/fc5c695a96fa0b91f9110ddd088130ab98192449/lib/generators/graphql/templates/graphql_controller.erb#L6) that allows for outside API access.  This was something that I needed to do each time I installed Hai on a demo app and allows us to access graphiql immediately after running the script.  If we don't run this, we get the error `Can't verify CSRF token authenticity.` when hitting graphiql

* I renamed the REST installation generator so that it follows the naming convention we used for the GraphQL script.  We can run this now by running `rails generate hai:install:rails`

* I added a third generator that runs both the GraphQL and REST generators.  More a convenience feature then anything

* Add the `.vscode` folder to .gitignore. 